### PR TITLE
Added missing bitwise or operator for QFlags flags

### DIFF
--- a/axis.sip
+++ b/axis.sip
@@ -195,3 +195,6 @@ signals:
   void selectionChanged(const QCPAxis::SelectableParts &parts);
   void selectableChanged(const QCPAxis::SelectableParts &parts);
 };
+
+QFlags<QCPAxis::AxisType> operator|(QCPAxis::AxisType f1, QFlags<QCPAxis::AxisType> f2);
+QFlags<QCPAxis::SelectablePart> operator|(QCPAxis::SelectablePart f1, QFlags<QCPAxis::SelectablePart> f2);

--- a/global.sip
+++ b/global.sip
@@ -94,3 +94,8 @@ void setMarginValue(QMargins &margins, QCP::MarginSide side, int value);
 int getMarginValue(const QMargins &margins, QCP::MarginSide side);
 
 };  // Namespace QCP
+
+QFlags<QCP::MarginSide> operator|(QCP::MarginSide f1, QFlags<QCP::MarginSide> f2);
+QFlags<QCP::AntialiasedElement> operator|(QCP::AntialiasedElement f1, QFlags<QCP::AntialiasedElement> f2);
+QFlags<QCP::PlottingHint> operator|(QCP::PlottingHint f1, QFlags<QCP::PlottingHint> f2);
+QFlags<QCP::Interaction> operator|(QCP::Interaction f1, QFlags<QCP::Interaction> f2);

--- a/layoutelement-legend.sip
+++ b/layoutelement-legend.sip
@@ -121,3 +121,5 @@ signals:
   void selectionChanged(QCPLegend::SelectableParts parts);
   void selectableChanged(QCPLegend::SelectableParts parts);
 };
+
+QFlags<QCPLegend::SelectablePart> operator|(QCPLegend::SelectablePart f1, QFlags<QCPLegend::SelectablePart> f2);

--- a/painter.sip
+++ b/painter.sip
@@ -45,3 +45,5 @@ public:
   // non-virtual methods:
   void makeNonCosmetic();
 };
+
+QFlags<QCPPainter::PainterMode> operator|(QCPPainter::PainterMode f1, QFlags<QCPPainter::PainterMode> f2);

--- a/scatterstyle.sip
+++ b/scatterstyle.sip
@@ -75,3 +75,5 @@ public:
   void drawShape(QCPPainter *painter, const QPointF &pos) const;
   void drawShape(QCPPainter *painter, double x, double y) const;
 };
+
+QFlags<QCPScatterStyle::ScatterProperty> operator|(QCPScatterStyle::ScatterProperty f1, QFlags<QCPScatterStyle::ScatterProperty> f2);


### PR DESCRIPTION
It's found out that that statements like "axRect.setAutoMargins(QCP.msLeft | QCP.msRight)" is not working because python converts enum value to int and then cannot convert it back to QFlags. 

This happens because bitwise or operator for QFlags-value is absent in python bindings. I have added this operator to all usages of QFlags as well as it is defined in PyQt itself.